### PR TITLE
Corrects file suffixes for c++ and c# files

### DIFF
--- a/src/helper.rs
+++ b/src/helper.rs
@@ -198,8 +198,8 @@ mod file {
         match l {
             "bash" => Ok("sh"),
             "c" => Ok("c"),
-            "cpp" => Ok("c"),
-            "csharp" => Ok("c"),
+            "cpp" => Ok("cpp"),
+            "csharp" => Ok("cs"),
             "golang" => Ok("go"),
             "java" => Ok("java"),
             "javascript" => Ok("js"),


### PR DESCRIPTION
Corrects the file suffixes for c++ and c# files from c to cpp and cs respectively.