### PR TITLE
Allow for custom testcases with the `leetcode test` command, and some minor edits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Cargo.lock
 **/*.rs.bk
 .DS_Store
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 **/*.rs.bk
+.DS_Store

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -186,6 +186,7 @@ impl Cache {
         &self,
         run: Run,
         rfid: i32,
+        testcase: Option<String>
     ) -> Result<(HashMap<&'static str, String>, [String; 2]), Error> {
         trace!("pre run code...");
         use crate::helper::code_path;
@@ -207,7 +208,11 @@ impl Cache {
 
         // pass manually data
         json.insert("name", p.name.to_string());
-        json.insert("data_input", d.case);
+        match testcase {
+            Some(case) => json.insert("data_input", case),
+            _ => json.insert("data_input", d.case)
+
+        };
 
         let url = match run {
             Run::Test => conf.sys.urls.get("test")?.replace("$slug", &p.slug),
@@ -251,10 +256,10 @@ impl Cache {
         Ok(res)
     }
 
-    /// Exec problem fliter —— Test or Submit
-    pub fn exec_problem(&self, rfid: i32, run: Run) -> Result<VerifyResult, Error> {
-        trace!("Exec problem fliter —— Test or Submit");
-        let pre = self.pre_run_code(run.clone(), rfid)?;
+    /// Exec problem filter —— Test or Submit
+    pub fn exec_problem(&self, rfid: i32, run: Run, testcase: Option<String>) -> Result<VerifyResult, Error> {
+        trace!("Exec problem filter —— Test or Submit");
+        let pre = self.pre_run_code(run.clone(), rfid, testcase)?;
         let json = pre.0;
 
         let run_res: RunCode = self

--- a/src/cache/models.rs
+++ b/src/cache/models.rs
@@ -261,7 +261,7 @@ impl std::fmt::Display for VerifyResult {
                         "       Runtime: ".dimmed(),
                         &self.status.status_runtime.dimmed(),
                         "\n  Your input:    ",
-                        &self.data_input.replace("\n", ", "),
+                        &self.data_input.replace("\n", "↩"),
                         "\n  Output:        ",
                         ca,
                         "\n  Expected:      ",
@@ -331,7 +331,7 @@ impl std::fmt::Display for VerifyResult {
                         "   Runtime: ".dimmed(),
                         &self.status.status_runtime.dimmed(),
                         "\n  Your input:    ",
-                        &self.data_input.replace("\n", ", "),
+                        &self.data_input.replace("\n", "↩"),
                         "\n  Output:        ",
                         ca,
                         "\n  Expected:      ",
@@ -387,7 +387,7 @@ impl std::fmt::Display for VerifyResult {
                 &self.status.status_msg.red().bold(),
                 &self.error.full_compile_error
             ),
-            _ => write!(f, "{}", "\nUnKnow Error...\n".red().bold()),
+            _ => write!(f, "{}", "\nUnknown Error...\n".red().bold()),
         }
     }
 }

--- a/src/cmds/exec.rs
+++ b/src/cmds/exec.rs
@@ -41,7 +41,7 @@ impl Command for ExecCommand {
 
         let id: i32 = m.value_of("id")?.parse()?;
         let cache = Cache::new()?;
-        let res = cache.exec_problem(id, Run::Submit)?;
+        let res = cache.exec_problem(id, Run::Submit, None)?;
 
         println!("{}", res);
         Ok(())

--- a/src/cmds/test.rs
+++ b/src/cmds/test.rs
@@ -33,14 +33,26 @@ impl Command for TestCommand {
                     .required(true)
                     .help("question id"),
             )
+            .arg(
+                Arg::with_name("testcase")
+                    .takes_value(true)
+                    .required(false)
+                    .help("custom testcase"),
+            )
     }
 
     /// `test` handler
     fn handler(m: &ArgMatches) -> Result<(), crate::Error> {
         use crate::cache::{Cache, Run};
         let id: i32 = m.value_of("id")?.parse()?;
+        let testcase = m.value_of("testcase");
+        let case_str: Option<String>;
+        match testcase {
+            Some(case) => case_str = Option::from(case.replace("\\n", "\n").to_string()),
+            _ => case_str = None,
+        }
         let cache = Cache::new()?;
-        let res = cache.exec_problem(id, Run::Test)?;
+        let res = cache.exec_problem(id, Run::Test, case_str)?;
 
         println!("{}", res);
         Ok(())

--- a/src/cmds/test.rs
+++ b/src/cmds/test.rs
@@ -25,7 +25,7 @@ impl Command for TestCommand {
     fn usage<'a, 'edit>() -> App<'a, 'edit> {
         use clap::{Arg, SubCommand};
         SubCommand::with_name("test")
-            .about("Edit question by id")
+            .about("Test question by id")
             .visible_alias("t")
             .arg(
                 Arg::with_name("id")


### PR DESCRIPTION
Now allows for an optional command line argument after `leetcode test` so that a custom test case can be provided. Test cases provided can be multiline with a \n.

Adds to the `.gitignore` `.DS_Store` and `.idea` files. Now macOS trash files and CLion/Intellij IDE support files are ignored.

Also makes a slight visual change so that when test cases are displayed in the CLI a ↩ (newline) character is used instead of a , (comma) to signify multi line input test cases.

