### PR TITLE
Display stdout for test and execute commands, fix minor spacing in results displayed

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -18,11 +18,16 @@ pub fn conn(p: String) -> SqliteConnection {
 }
 
 /// Condition submit or test
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Run {
     Test,
     Submit,
 }
+
+impl std::default::Default for Run {
+    fn default() -> Self { Run::Submit }
+}
+
 
 /// Requests if data not download
 #[derive(Clone)]
@@ -285,6 +290,7 @@ impl Cache {
 
         res.name = json.get("name")?.to_string();
         res.data_input = json.get("data_input")?.to_string();
+        res.result_type = run;
         Ok(res)
     }
 


### PR DESCRIPTION
Now if any output exists it will be displayed when the test/execute commands are run. If no output exists nothing is displayed. 

Also fixes spacing of results displayed to provide consistency.