### PR TITLE
Make programmable support to be an advanced feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,9 @@ keyring = "0.8.0"
 log = "0.4"
 openssl = "0.10.26"
 rand = "0.7.2"
-serde = "1.0.104"
-serde_derive = "1.0.104"
+serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.44"
-pyo3 = "0.8.5"
+pyo3 = { version = "0.8.5", optional = true }
 toml = "0.5.5"
 escaper = "0.1.0"
 
@@ -40,3 +39,6 @@ features = ["sqlite"]
 [dependencies.reqwest]
 version = "0.10.3"
 features = ["blocking", "gzip", "json"]
+
+[features]
+pym = ["pyo3"]

--- a/src/cmds/list.rs
+++ b/src/cmds/list.rs
@@ -132,9 +132,12 @@ impl Command for ListCommand {
 
         // filtering...
         // pym scripts
-        if m.is_present("plan") {
-            let ids = crate::pym::exec(m.value_of("plan").unwrap_or(""))?;
-            crate::helper::squash(&mut ps, ids)?;
+        #[cfg(feature = "pym")]
+        {
+            if m.is_present("plan") {
+                let ids = crate::pym::exec(m.value_of("plan").unwrap_or(""))?;
+                crate::helper::squash(&mut ps, ids)?;
+            }
         }
 
         // filter tag

--- a/src/cmds/pick.rs
+++ b/src/cmds/pick.rs
@@ -78,9 +78,12 @@ impl Command for PickCommand {
 
         // filtering...
         // pym scripts
-        if m.is_present("plan") {
-            let ids = crate::pym::exec(m.value_of("plan").unwrap_or(""))?;
-            crate::helper::squash(&mut problems, ids)?;
+        #[cfg(feature = "pym")]
+        {
+            if m.is_present("plan") {
+                let ids = crate::pym::exec(m.value_of("plan").unwrap_or(""))?;
+                crate::helper::squash(&mut problems, ids)?;
+            }
         }
 
         // tag filter

--- a/src/err.rs
+++ b/src/err.rs
@@ -124,6 +124,7 @@ impl std::convert::From<openssl::error::ErrorStack> for Error {
 }
 
 // pyo3
+#[cfg(feature = "pym")]
 impl std::convert::From<pyo3::PyErr> for Error {
     fn from(_: pyo3::PyErr) -> Self {
         Error::ScriptError("Python script went Error".to_string())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,7 @@ pub mod err;
 pub mod flag;
 pub mod helper;
 pub mod plugins;
+#[cfg(feature = "pym")]
 pub mod pym;
 
 // re-exports


### PR DESCRIPTION
Hi, I have an idea to make programmable support to be an advanced feature, which makes compile faster.

The underlying reason is I used to run this tool in dev mode, and pyo3 was recompiling frequently, it's a little annoying. So maybe we can make it to be an optional feature:)

BTW if you think this feature is important to end user, we can make it default on, and we still got `--no-default-features` with `cargo run` to disable it temporary.

What do you think?