### PR TITLE
[Testsing] Adds test data files

### DIFF
--- a/src/cache/models.rs
+++ b/src/cache/models.rs
@@ -118,6 +118,7 @@ pub struct Question {
     pub stats: Stats,
     pub defs: CodeDefintion,
     pub case: String,
+    pub all_cases: String,
     pub metadata: MetaData,
     pub test: bool,
     pub t_content: String,
@@ -166,7 +167,7 @@ mod question {
     #[derive(Debug, Default, Serialize, Deserialize)]
     pub struct MetaData {
         pub name: Option<String>,
-        pub params: Option<Param>,
+        pub params: Option<Vec<Param>>,
         pub r#return: Return,
     }
 
@@ -378,7 +379,7 @@ impl std::fmt::Display for VerifyResult {
             // if anybody reach this, welcome to fix this!
             13 | 14 => write!(f, "\n{}\n", &self.status.status_msg.yellow().bold(),)?,
             // Runtime error
-            15 => write!(f, "\n{}\n", &self.status.status_msg.red().bold())?,
+            15 => write!(f, "\n{}\n{}\n'", &self.status.status_msg.red().bold(), &self.status.runtime_error)?,
             // Compile Error
             20 => write!(
                 f,
@@ -479,6 +480,8 @@ mod verify {
         pub status_memory: String,
         #[serde(default)]
         pub status_runtime: String,
+        #[serde(default)]
+        pub runtime_error: String
     }
 
     #[derive(Debug, Default, Deserialize)]

--- a/src/cache/parser.rs
+++ b/src/cache/parser.rs
@@ -43,6 +43,10 @@ pub fn desc(q: &mut Question, v: Value) -> Result<(), Error> {
         stats: serde_json::from_str(o.get("stats")?.as_str()?)?,
         defs: serde_json::from_str(o.get("codeDefinition")?.as_str()?)?,
         case: o.get("sampleTestCase")?.as_str()?.to_string(),
+        all_cases: o.get("exampleTestcases")
+                .unwrap_or(o.get("sampleTestCase")?) // soft fail to the sampleTestCase
+                .as_str()?
+                .to_string(),
         metadata: serde_json::from_str(o.get("metaData")?.as_str()?)?,
         test: o.get("enableRunCode")?.as_bool()?,
         t_content: o

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,6 +1,6 @@
 //! A set of helper traits
 pub use self::digit::Digit;
-pub use self::file::{code_path, load_script};
+pub use self::file::{code_path, load_script, test_cases_path};
 pub use self::filter::{filter, squash};
 pub use self::html::HTML;
 
@@ -282,6 +282,23 @@ mod file {
     }
 
     use crate::cache::models::Problem;
+
+    /// Generate test casese path by fid
+    pub fn test_cases_path(target: &Problem) -> Result<String, crate::Error> {
+        let conf = crate::cfg::locate()?;
+
+        let mut path = format!(
+            "{}/{}.tests.dat",
+            conf.storage.code()?,
+            conf.code.pick,
+        );
+
+        path = path.replace("${fid}", &target.fid.to_string());
+        path = path.replace("${slug}", &target.slug.to_string());
+
+        Ok(path)
+    }
+
     /// Generate code path by fid
     pub fn code_path(target: &Problem, l: Option<String>) -> Result<String, crate::Error> {
         let conf = crate::cfg::locate()?;

--- a/src/plugins/leetcode.rs
+++ b/src/plugins/leetcode.rs
@@ -135,6 +135,7 @@ impl LeetCode {
                 "    stats",
                 "    codeDefinition",
                 "    sampleTestCase",
+                "    exampleTestcases",
                 "    enableRunCode",
                 "    metaData",
                 "    translatedContent",


### PR DESCRIPTION
Scope: introduces a test data files that are created alongside with code
files. Those files are pre-filled with sample tests from leetcode and
could be extended with the custom values. CLI test input has always a
priority over test files. If test file is missing and test input is not
provided, sample test case is used as was previously.

Changes:
- Fixes a bug with missing Vec<> inside of optional
- Adds runtime error message to the output
- Generates a test file when test is created

Fixes #26 