### PR TITLE
Fix rendering problem with a superscript bigger than 10

### DIFF
--- a/src/helper.rs
+++ b/src/helper.rs
@@ -113,6 +113,7 @@ mod html {
 
     pub fn superscript(n: u8) -> String {
         match n {
+            x if x >= 10 => format!("{}{}", superscript(n / 10), superscript(n % 10)),
             0 => "⁰".to_string(),
             1 => "¹".to_string(),
             2 => "²".to_string(),
@@ -123,18 +124,13 @@ mod html {
             7 => "⁷".to_string(),
             8 => "⁸".to_string(),
             9 => "⁹".to_string(),
-            x if x > 10 => (superscript(n / 10).parse().unwrap_or(0)
-                + superscript(n % 10).parse().unwrap_or(0))
-            .to_string(),
             _ => n.to_string(),
         }
     }
 
     pub fn subscript(n: u8) -> String {
         match n {
-            x if x >= 10 => (subscript(n / 10).parse().unwrap_or(0)
-                + subscript(n % 10).parse().unwrap_or(0))
-            .to_string(),
+            x if x >= 10 => format!("{}{}", subscript(n / 10), subscript(n % 10)),
             0 => "₀".to_string(),
             1 => "₁".to_string(),
             2 => "₂".to_string(),


### PR DESCRIPTION
The issue [leetcode pick: wrong constraints](https://github.com/clearloop/leetcode-cli/issues/38) is caused by the code at [helper.rs#L126:1](https://sourcegraph.com/github.com/clearloop/leetcode-cli@8e246ad5e2c2246cec42c4f16e30e6b17729687d/-/blob/src/helper.rs#L126:1
)

1. `superscript(n / 10).parse().unwrap_or(0)` and `superscript(n % 10).parse().unwrap_or(0)` always fail because `parse` function did not specify the type.
2. Even if you use `parse::<u32>()`, the code still fails because parsing superscript(e.g. `³` ) produces invalid digit error.

I believe that you want to concatenate two superscripts here. 
This commit produces a valid representation.

ex) ` -2³¹ <= num <= 2³¹ - 1`