### PR TITLE
Adds space between test results

### DIFF
--- a/src/cache/models.rs
+++ b/src/cache/models.rs
@@ -245,12 +245,12 @@ impl std::fmt::Display for VerifyResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let ca = match &self.code_answer.len() {
             1 => self.code_answer[0].to_string(),
-            _ => self.code_answer.join(""),
+            _ => self.code_answer.join("↩ "),
         };
 
         let eca = match &self.expected.expected_code_answer.len() {
             1 => self.expected.expected_code_answer[0].to_string(),
-            _ => self.expected.expected_code_answer.join(""),
+            _ => self.expected.expected_code_answer.join("↩ "),
         };
 
         debug!("{:#?}", &self);


### PR DESCRIPTION
`leetcode t 127`

with two testcases

Before:
![before](https://user-images.githubusercontent.com/79659361/125850446-8b11d404-de8b-4887-a8e0-84f2c82f02b9.png)
After:
![after](https://user-images.githubusercontent.com/79659361/125850524-4b15695b-6c37-42d2-92cc-f17137449a9b.png)
