### PR TITLE
fix(formatting): swap space to where it belongs

### DIFF
--- a/src/cache/models.rs
+++ b/src/cache/models.rs
@@ -314,9 +314,9 @@ impl std::fmt::Display for VerifyResult {
                          {}.\n\n\
                          {}{}\
                          , less than \
-                         {}{} \
+                         {}{}\
                          of \
-                         {}{}.\n\n",
+                         {} {}.\n\n",
                         "Success\n\n".green().bold(),
                         "Runtime: ".dimmed(),
                         &self.status.status_runtime.bold(),


### PR DESCRIPTION
There was problem with formatting
![formatting_problem](https://user-images.githubusercontent.com/79659361/126045982-3675e8c7-965d-4ff0-8f9f-d2db4e8bb78d.png)
Now it's gone
![formatting_problem1](https://user-images.githubusercontent.com/79659361/126046011-c7293119-fcc1-4f75-9ae4-6b770933f3d3.png)
