### PR TITLE
Add count padding

### DIFF
--- a/src/cmds/stat.rs
+++ b/src/cmds/stat.rs
@@ -67,7 +67,7 @@ impl Command for StatCommand {
         }
 
         // level: len = 8
-        // count: len = 8
+        // count: len = 10
         // percent: len = 16
         // chart: len = 32
         // title

--- a/src/cmds/stat.rs
+++ b/src/cmds/stat.rs
@@ -105,7 +105,7 @@ impl Command for StatCommand {
             let count = format!("{}/{}", l.1, l.0);
             let pct = format!("( {:.2} %)", checked_div(100.0 * l.1, l.0));
             let mut line = "".to_string();
-            line.push_str(&" ".digit(8 - (count.len() as i32)));
+            line.push_str(&" ".digit(10 - (count.len() as i32)));
             line.push_str(&count);
             line.push_str(&" ".digit(12 - (pct.len() as i32)));
             line.push_str(&pct);


### PR DESCRIPTION
I'm getting error running `leetcode stat`. This should fix it.

The `stat` command assume that the `count` field will be less than 8 char long. However, the are over one thousand medium level problems in leetcode now. The maximum length of a count field now is `1000/1000`, which is 9 char long.

This is a temporary fix. A better solution would be to decide the length based on the response it received from Leetcode.

------
Before and after fix:

<img width="956" alt="leetcode-cli" src="https://user-images.githubusercontent.com/38187913/147545457-4c647bde-e81a-45d8-9b52-964f3c268015.png">
