### PR TITLE
Add flake.nix for Nix users

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,94 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1637014545,
+        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1644151317,
+        "narHash": "sha256-TpXGBYCFKvEN7Q+To45rn4kqTbLPY4f56rF6ymUGGRE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "942b0817e898262cc6e3f0a5f706ce09d8f749f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1637453606,
+        "narHash": "sha256-Gy6cwUswft9xqsjWxFYEnx/63/qzaFUwatcbV5GF/GQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8afc4e543663ca0a6a4f496262cd05233737e732",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "utils": "utils"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1644287662,
+        "narHash": "sha256-KkdR8VSpsOXb2ZlOeBrt5sF5a9dfAPW5KH0zrInoVl0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "2eae19e246433530998cbf239d5505b7b87bc854",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,59 @@
+{
+  description = "Leet your code in command-line.";
+
+  inputs.nixpkgs.url      = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.rust-overlay.url = "github:oxalica/rust-overlay";
+  inputs.utils.url        = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, rust-overlay, utils, ... }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; overlays = [ rust-overlay.overlay ]; };
+
+        platform = with pkgs; makeRustPlatform {
+          rustc = rust-bin.nightly.latest.minimal;
+          cargo = rust-bin.nightly.latest.minimal;
+        };
+        package = with pkgs; platform.buildRustPackage rec {
+          pname = "leetcode-cli";
+          version = "0.3.10";
+
+          src = fetchCrate {
+            inherit pname version;
+            sha256 = "SkJLA49AXNTpiWZByII2saYLyN3bAAJTlCvhamlOEXA=";
+          };
+
+          cargoSha256 = "xhKF4qYOTdt8iCSPY5yT8tH3l54HdkOAIS2SBGzqsdo=";
+
+          # a nightly compiler is required unless we use this cheat code.
+          RUSTC_BOOTSTRAP = 0;
+
+          # CFG_RELEASE = "${rustPlatform.rust.rustc.version}-nightly";
+          CFG_RELEASE_CHANNEL = "ngihtly";
+
+          nativeBuildInputs = [
+            pkg-config
+            rust-bin.stable.latest.default
+          ];
+
+          buildInputs = [
+            openssl
+            dbus
+            sqlite
+          ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
+
+          meta = with pkgs.lib; {
+            description = "Leet your code in command-line.";
+            homepage = "https://github.com/clearloop/leetcode-cli";
+            licenses = licenses.mit;
+            maintainers = with maintainers; [ congee ];
+            mainProgram = "leetcode";
+          };
+        };
+      in
+      {
+        defaultPackage = package;
+        overlay = final: prev: { leetcode-cli = package; };
+      }
+    );
+}


### PR DESCRIPTION
This change allows a reproducible build of `leetcode-cli` for all nix users. I have tested this flake on x86_64-linux and aarch64-darwin. Just in case, nix is a tool for creating reproducible builds. Just one configuration file can provide the same version of software for all users. Imagine developers will not need to say "Well, it works on my machine".

Once this pull request is accepted, we may move on to submit a package to https://github.com/NixOS/nixpkgs. It would be nice to see adoption of `leetcode-cli` to nix users :D