### PR TITLE
Raise Error::CookieError more often

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -311,6 +311,12 @@ impl Cache {
             .await?;
         trace!("Run code result {:#?}", run_res);
 
+        // Check if leetcode accepted the Run request
+        if match run {
+            Run::Test => run_res.interpret_id.is_empty(),
+            Run::Submit => run_res.submission_id == 0
+        } { return Err(Error::CookieError) }
+
         let mut res: VerifyResult = VerifyResult::default();
         while res.state != "SUCCESS" {
             res = match run {

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -58,6 +58,27 @@ impl Cache {
         Ok(())
     }
 
+    async fn get_user_info(&self) -> Result<(String,bool), Error> {
+        let user = parser::user(
+            self.clone().0
+            .get_user_info().await?
+            .json().await?
+        );
+        match user {
+            None => Err(Error::NoneError),
+            Some(None) => Err(Error::CookieError),
+            Some(Some((s,b))) => Ok((s,b))
+        }
+    }
+
+    async fn is_session_bad(&self) -> bool {
+        // i.e. self.get_user_info().contains_err(Error::CookieError)
+        match self.get_user_info().await {
+            Err(Error::CookieError) => true,
+            _ => false
+        }
+    }
+
     /// Download leetcode problems to db
     pub async fn download_problems(self) -> Result<Vec<Problem>, Error> {
         info!("Fetching leetcode problems...");

--- a/src/cache/parser.rs
+++ b/src/cache/parser.rs
@@ -88,6 +88,21 @@ pub fn daily(v: Value) -> Option<i32> {
         .parse().ok()
 }
 
+/// user parser
+pub fn user(v: Value) -> Option<Option<(String,bool)>> {
+    // None => error while parsing
+    // Some(None) => User not found
+    // Some("...") => username
+    let user = v.as_object()?.get("data")?
+        .as_object()?.get("user")?;
+    if *user == Value::Null { return Some(None) }
+    let user = user.as_object()?;
+    Some(Some((
+        user.get("username")?.as_str()?.to_owned(),
+        user.get("isCurrentUserPremium")?.as_bool()?
+    )))
+}
+
 pub use ss::ssr;
 /// string or squence
 mod ss {

--- a/src/plugins/leetcode.rs
+++ b/src/plugins/leetcode.rs
@@ -121,6 +121,34 @@ impl LeetCode {
         .await
     }
 
+    pub async fn get_user_info(self) -> Result<Response, Error> {
+        trace!("Requesting user info...");
+        let url = &self.conf.sys.urls.get("graphql").ok_or(Error::NoneError)?;
+        let mut json: Json = HashMap::new();
+        json.insert("operationName", "a".to_string());
+        json.insert(
+            "query",
+            "query a {
+                 user {
+                     username
+                     isCurrentUserPremium
+                 }
+             }".to_owned()
+        );
+
+        Req {
+            default_headers: self.default_headers,
+            refer: None,
+            info: false,
+            json: Some(json),
+            mode: Mode::Post,
+            name: "get_user_info",
+            url: (*url).to_string(),
+        }
+        .send(&self.client)
+        .await
+    }
+
     /// Get daily problem
     pub async fn get_question_daily(self) -> Result<Response, Error> {
         trace!("Requesting daily problem...");


### PR DESCRIPTION
Related to #55 #57 (not #60, that is unaddressed in this PR)

Previously:
```sh
$ leetcode t 1
[INFO  leetcode_cli::plugins::leetcode] Sending code to judge...
error: expected value at line 1 column 1
```
Now:
```sh
$ cargo run t 1
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/leetcode t 1`
[INFO  leetcode_cli::plugins::leetcode] Sending code to judge...
error: Your leetcode cookies seems expired, please make sure you have logined in leetcode.com with chrome.  Either you can handwrite your `LEETCODE_SESSION` and `csrf` into `leetcode.toml`, more info please checkout this: https://github.com/clearloop/leetcode-cli/blob/master/README.md#cookies
```

I have introduced a general method, `is_session_bad()`, which should reliably answer the question of, "is `LEETCODE_SESSION` invalid?". Emphasis on _should_, because I have attached no additional tests in this PR as well.
Some of the code added is not very good. Please edit/criqitue as you see fit.