### PR TITLE
feat: refactor config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ async-trait = "0.1.56"
 tokio = { version = "1.19.2", features = ["full"] }
 clap = { version = "4", features = ["cargo"] }
 colored = "2.0.0"
-dirs = "4.0.0"
 env_logger = "0.9.0"
 keyring = "1.2.0"
 log = "0.4.17"
@@ -32,6 +31,7 @@ serde_json = "1.0.82"
 toml = "0.5.9"
 regex = "1.6.0"
 scraper = "0.13.0"
+etcetera = "0.4.0"
 
 [dependencies.diesel]
 version = "1.4.8"

--- a/src/cmds/data.rs
+++ b/src/cmds/data.rs
@@ -1,6 +1,6 @@
 //! Cache managger
 use super::Command;
-use crate::{cache::Cache, helper::Digit, Error};
+use crate::{cache::Cache, helper::Digit, Config, Error};
 use async_trait::async_trait;
 use clap::{Arg, ArgAction, ArgMatches, Command as ClapCommand};
 use colored::Colorize;
@@ -53,7 +53,7 @@ impl Command for DataCommand {
         use std::path::Path;
 
         let cache = Cache::new()?;
-        let path = cache.0.conf.storage.cache()?;
+        let path = Config::problems_filepath()?;
         let f = File::open(&path)?;
         let len = format!("{}K", f.metadata()?.len() / 1000);
 

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -186,12 +186,16 @@ mod file {
         }
     }
 
-    use crate::{cache::models::Problem, Error};
+    use crate::{cache::models::Problem, Config, Error};
 
     /// Generate test cases path by fid
     pub fn test_cases_path(problem: &Problem) -> Result<String, Error> {
-        let conf = crate::cfg::locate()?;
-        let mut path = format!("{}/{}.tests.dat", conf.storage.code()?, conf.code.pick);
+        let conf = Config::config_content()?;
+        let mut path = format!(
+            "{}/{}.tests.dat",
+            Config::code_dir_or_create()?,
+            conf.code.pick
+        );
 
         path = path.replace("${fid}", &problem.fid.to_string());
         path = path.replace("${slug}", &problem.slug.to_string());
@@ -200,7 +204,7 @@ mod file {
 
     /// Generate code path by fid
     pub fn code_path(problem: &Problem, l: Option<String>) -> Result<String, Error> {
-        let conf = crate::cfg::locate()?;
+        let conf = Config::config_content()?;
         let mut lang = conf.code.lang;
         if l.is_some() {
             lang = l.ok_or(Error::NoneError)?;
@@ -208,7 +212,7 @@ mod file {
 
         let mut path = format!(
             "{}/{}.{}",
-            conf.storage.code()?,
+            Config::code_dir_or_create()?,
             conf.code.pick,
             suffix(&lang)?,
         );
@@ -223,9 +227,8 @@ mod file {
     pub fn load_script(module: &str) -> Result<String, crate::Error> {
         use std::fs::File;
         use std::io::Read;
-        let conf = crate::cfg::locate()?;
         let mut script = "".to_string();
-        File::open(format!("{}/{}.py", conf.storage.scripts()?, module))?
+        File::open(format!("{}/{}.py", Config::script_dir_or_create()?, module))?
             .read_to_string(&mut script)?;
 
         Ok(script)

--- a/src/plugins/chrome.rs
+++ b/src/plugins/chrome.rs
@@ -1,4 +1,4 @@
-use crate::{cache, Error};
+use crate::{cache, Config, Error};
 use diesel::prelude::*;
 use keyring::Entry;
 use openssl::{hash, pkcs5, symm};
@@ -41,7 +41,7 @@ impl std::string::ToString for Ident {
 
 /// Get cookies from chrome storage
 pub fn cookies() -> Result<Ident, crate::Error> {
-    let ccfg = crate::cfg::locate()?.cookies;
+    let ccfg = Config::config_content()?.cookies;
     if !ccfg.csrf.is_empty() && !ccfg.session.is_empty() {
         return Ok(Ident {
             csrf: ccfg.csrf,
@@ -53,7 +53,7 @@ pub fn cookies() -> Result<Ident, crate::Error> {
     use self::schema::cookies::dsl::*;
     trace!("Derive cookies from google chrome...");
 
-    let home = dirs::home_dir().ok_or(Error::NoneError)?;
+    let home = Config::home_dir();
     let p = match std::env::consts::OS {
         "macos" => home.join("Library/Application Support/Google/Chrome/Default/Cookies"),
         "linux" => home.join(".config/google-chrome/Default/Cookies"),


### PR DESCRIPTION
fix #63, For configuring file directory consistency
* use `~/.config/leetcode` for config directory(include `leetcode.toml` and `scripts`).

* use `~/.cache/leetcode` for cache directory(include `problems` and `code` cache).

Follow up plans:
- [ ] add tests (unit and integration)
