### PR TITLE
fix: snake case editor_args parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ For example, given this config (can be found in `~/.leetcode/leetcode.toml`, it 
 [code]
 lang = "rust"
 editor = "emacs"
+# Optional parameter
+editor_args = ['-nw']
 ```
 
 #### 1. <kbd>pick</kbd>

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -138,7 +138,7 @@ pub struct Urls {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Code {
     pub editor: String,
-    #[serde(rename(serialize = "editor-args", deserialize = "editor-args"))]
+    #[serde(rename(serialize = "editor_args", deserialize = "editor_args"))]
     pub editor_args: Option<Vec<String>>,
     pub edit_code_marker: bool,
     pub start_marker: String,

--- a/src/cmds/edit.rs
+++ b/src/cmds/edit.rs
@@ -140,7 +140,7 @@ impl Command for EditCommand {
         // ```toml
         // [code]
         // editor = "emacsclient"
-        // editor-args = [ "-n", "-s", "doom" ]
+        // editor_args = [ "-n", "-s", "doom" ]
         // ```
         //
         // ```rust


### PR DESCRIPTION
* Change editor_args -> editor-args to follow the project naming convention
* Update doc