### PR TITLE
Shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc443334c81a804575546c5a8a79b4913b50e28d69232903604cada1de817ce"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1061,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "clap_complete",
  "colored",
  "diesel",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ toml = "0.5.9"
 regex = "1.6.0"
 scraper = "0.13.0"
 anyhow = "1.0.71"
+clap_complete = "4.3.2"
 
 [dependencies.diesel]
 version = "2.0.3"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@
 cargo install leetcode-cli
 ```
 
+### For shell completions:
+
+For Bash and Zsh (by default picks up `$SHELL` from environment)
+```sh
+eval "$(leetcode completions)"
+```
+Copy the line above to `.bash_profile` or `.zshrc`
+
+You can obtain specific shell configuration using.
+
+```sh
+leetcode completions fish
+```
+
 ## Usage
 
 **Make sure you have logged in to `leetcode.com` with `Firefox`**. See [Cookies](#cookies) for why you need to do this first.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
 cargo install leetcode-cli
 ```
 
-### For shell completions:
+<details>
+<summary>Shell completions</summary>
 
 For Bash and Zsh (by default picks up `$SHELL` from environment)
 ```sh
@@ -28,11 +29,13 @@ eval "$(leetcode completions)"
 ```
 Copy the line above to `.bash_profile` or `.zshrc`
 
-You can obtain specific shell configuration using.
+You may also obtain specific shell configuration using.
 
 ```sh
 leetcode completions fish
 ```
+
+</details>
 
 ## Usage
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,7 @@ use crate::{
     err::Error,
     flag::{Debug, Flag},
 };
-use clap::{crate_name, crate_version};
+use clap::crate_version;
 use log::LevelFilter;
 
 /// This should be called before calling any cli method or printing any output.
@@ -26,7 +26,8 @@ pub fn reset_signal_pipe_handler() {
 /// Get matches
 pub async fn main() -> Result<(), Error> {
     reset_signal_pipe_handler();
-    let mut cmd = clap::Command::new(crate_name!())
+
+    let mut cmd = clap::Command::new("leetcode")
         .version(crate_version!())
         .about("May the Code be with You 👻")
         .subcommands(vec![

--- a/src/cmds/completions.rs
+++ b/src/cmds/completions.rs
@@ -1,0 +1,62 @@
+//! Completions command
+
+use super::Command;
+use crate::err::Error;
+use async_trait::async_trait;
+use clap::crate_name;
+use clap::{Arg, ArgAction, ArgMatches, Command as ClapCommand};
+use clap_complete::{generate, Generator, Shell};
+
+/// Abstract shell completions command
+///
+/// ```sh
+/// Generate shell Completions
+
+/// USAGE:
+///     leetcode completions <shell>
+
+/// ARGUMENTS:
+///     <shell>  [possible values: bash, elvish, fish, powershell, zsh]
+/// ```
+pub struct CompletionCommand;
+
+#[async_trait]
+impl Command for CompletionCommand {
+    /// `pick` usage
+    fn usage() -> ClapCommand {
+        ClapCommand::new("completions")
+            .about("Generate shell Completions")
+            .visible_alias("c")
+            .arg(
+                Arg::new("shell")
+                    .action(ArgAction::Set)
+                    .value_parser(clap::value_parser!(Shell)),
+            )
+    }
+
+    async fn handler(_m: &ArgMatches) -> Result<(), Error> {
+        // defining custom handler to print the completions. Handler method signature limits taking
+        // other params. We need &ArgMatches and &mut ClapCommand to generate completions.
+        println!("Don't use this handler. Does not implement the functionality to print completions. Use completions_handler() below.");
+        Ok(())
+    }
+}
+
+fn get_completions_string<G: Generator>(gen: G, cmd: &mut ClapCommand) -> Result<String, Error> {
+    let mut v: Vec<u8> = Vec::new();
+    generate(gen, cmd, crate_name!(), &mut v);
+    Ok(String::from_utf8(v)?)
+}
+
+pub fn completion_handler(m: &ArgMatches, cmd: &mut ClapCommand) -> Result<(), Error> {
+    let shell = *m.get_one::<Shell>("shell").unwrap_or(
+        // if shell value is not provided try to get from the environment
+        {
+            println!("# Since shell arg value is not provided trying to get the default shell from the environment.");
+            &Shell::from_env().ok_or(Error::MatchError)?
+        }
+    );
+    let completions = get_completions_string(shell, cmd)?;
+    println!("{}", completions);
+    Ok(())
+}

--- a/src/cmds/completions.rs
+++ b/src/cmds/completions.rs
@@ -3,7 +3,6 @@
 use super::Command;
 use crate::err::Error;
 use async_trait::async_trait;
-use clap::crate_name;
 use clap::{Arg, ArgAction, ArgMatches, Command as ClapCommand};
 use clap_complete::{generate, Generator, Shell};
 
@@ -44,7 +43,8 @@ impl Command for CompletionCommand {
 
 fn get_completions_string<G: Generator>(gen: G, cmd: &mut ClapCommand) -> Result<String, Error> {
     let mut v: Vec<u8> = Vec::new();
-    generate(gen, cmd, crate_name!(), &mut v);
+    let name = cmd.get_name().to_string();
+    generate(gen, cmd, name, &mut v);
     Ok(String::from_utf8(v)?)
 }
 

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -24,6 +24,7 @@ pub trait Command {
     async fn handler(m: &ArgMatches) -> Result<(), Error>;
 }
 
+mod completions;
 mod data;
 mod edit;
 mod exec;
@@ -31,6 +32,7 @@ mod list;
 mod pick;
 mod stat;
 mod test;
+pub use completions::{completion_handler, CompletionCommand};
 pub use data::DataCommand;
 pub use edit::EditCommand;
 pub use exec::ExecCommand;

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,7 +1,7 @@
 //! Errors in leetcode-cli
 use crate::cmds::{Command, DataCommand};
 use colored::Colorize;
-use std::fmt;
+use std::{fmt, string::FromUtf8Error};
 
 // fixme: use this_error
 /// Error enum
@@ -17,6 +17,7 @@ pub enum Error {
     PremiumError,
     DecryptError,
     SilentError,
+    Utf8ParseError,
     NoneError,
     ChromeNotLogin,
     Anyhow(anyhow::Error),
@@ -61,6 +62,7 @@ impl std::fmt::Debug for Error {
             ),
             Error::ChromeNotLogin => write!(f, "maybe you not login on the Chrome, you can login and retry."),
             Error::Anyhow(e) => write!(f, "{} {}", e, e),
+            Error::Utf8ParseError => write!(f, "cannot parse utf8 from buff {}", e),
         }
     }
 }
@@ -69,6 +71,13 @@ impl std::fmt::Debug for Error {
 impl std::convert::From<reqwest::Error> for Error {
     fn from(err: reqwest::Error) -> Self {
         Error::NetworkError(err.to_string())
+    }
+}
+
+// utf8 parse
+impl std::convert::From<FromUtf8Error> for Error {
+    fn from(_err: FromUtf8Error) -> Self {
+        Error::Utf8ParseError
     }
 }
 


### PR DESCRIPTION
fixes  #128

- Using `clap_complete` to generate the shell completions for `Bash`, `Elvish`, `Fish`, `PowerShell`, `Zsh`
- Hardcoded the binary name since macro `crate_name!()` picks up package name i.e. `leetcode-cli`. That hinders shell completion.
- Added collapsible Readme description to provide support for the feature.