### PR TITLE
feat: inject code before and after leetcode boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ SUBCOMMANDS:
 
 ## Example
 
-For example, given this config (could be found at `~/.leetcode/leetcode.toml`):
+To configure leetcode-cli, create a file at `~/.leetcode/leetcode.toml`):
 
 ```toml
 [code]
@@ -185,6 +185,14 @@ pub fn three_sum(nums: Vec<i32>) -> Vec<Vec<i32>> {
 </details>
 
 <br>
+
+Some linting tools/lsps will throw errors unless the necessary libraries are imported. leetcode-cli can generate this boilerplate automatically if the `inject_before` key is set. Similarly, if you want to test out your code locally, you can automate that with `inject_after`. For c++ this might look something like:
+
+```toml
+[code]
+inject_before = ["#include<bits/stdc++.h", "using namespace std;"]
+inject_after = ["int main() {\n    Solution solution;\n\n}"]
+```
 
 #### 1. <kbd>pick</kbd>
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -356,7 +356,7 @@ impl Cache {
     ) -> Result<VerifyResult, Error> {
         trace!("Exec problem filter —— Test or Submit");
         let (json, [url, refer]) = self.pre_run_code(run.clone(), rfid, test_case).await?;
-        trace!("Pre run code result {:#?}, {}, {}", json, url, refer);
+        trace!("Pre-run code result {:#?}, {}, {}", json, url, refer);
 
         let text = self
             .0
@@ -367,7 +367,7 @@ impl Cache {
             .await?;
 
         let run_res: RunCode = serde_json::from_str(&text).map_err(|e| {
-            anyhow!("json error: {e}, plz double check your session and csrf config.")
+            anyhow!("JSON error: {e}, please double check your session and csrf config.")
         })?;
 
         trace!("Run code result {:#?}", run_res);

--- a/src/cmds/edit.rs
+++ b/src/cmds/edit.rs
@@ -93,8 +93,8 @@ impl Command for EditCommand {
                         file_code.write_all(p_desc_comment.as_bytes())?;
                         file_code.write_all(question_desc.as_bytes())?;
                     }
-                    if let Some(template) = &conf.code.template {
-                        for line in template {
+                    if let Some(inject_before) = &conf.code.inject_before {
+                        for line in inject_before {
                             file_code.write_all((line.to_string() + "\n").as_bytes())?;
                         }
                     }
@@ -116,6 +116,11 @@ impl Command for EditCommand {
                                 + "\n")
                                 .as_bytes(),
                         )?;
+                    }
+                    if let Some(inject_after) = &conf.code.inject_after {
+                        for line in inject_after {
+                            file_code.write_all((line.to_string() + "\n").as_bytes())?;
+                        }
                     }
 
                     if test_flag {

--- a/src/cmds/edit.rs
+++ b/src/cmds/edit.rs
@@ -93,6 +93,11 @@ impl Command for EditCommand {
                         file_code.write_all(p_desc_comment.as_bytes())?;
                         file_code.write_all(question_desc.as_bytes())?;
                     }
+                    if let Some(template) = &conf.code.template {
+                        for line in template {
+                            file_code.write_all((line.to_string() + "\n").as_bytes())?;
+                        }
+                    }
                     if conf.code.edit_code_marker {
                         file_code.write_all(
                             (conf.code.comment_leading.clone()

--- a/src/config/code.rs
+++ b/src/config/code.rs
@@ -16,14 +16,16 @@ pub struct Code {
     pub editor: String,
     #[serde(rename(serialize = "editor-args"), alias = "editor-args", default)]
     pub editor_args: Option<Vec<String>>,
-    #[serde(rename(serialize = "template"), alias = "template", default)]
-    pub template: Option<Vec<String>>,
     #[serde(default, skip_serializing)]
     pub edit_code_marker: bool,
     #[serde(default, skip_serializing)]
     pub start_marker: String,
     #[serde(default, skip_serializing)]
     pub end_marker: String,
+    #[serde(rename(serialize = "inject_before"), alias = "inject_before", default)]
+    pub inject_before: Option<Vec<String>>,
+    #[serde(rename(serialize = "inject_after"), alias = "inject_after", default)]
+    pub inject_after: Option<Vec<String>>,
     #[serde(default, skip_serializing)]
     pub comment_problem_desc: bool,
     #[serde(default, skip_serializing)]
@@ -42,10 +44,11 @@ impl Default for Code {
         Self {
             editor: "vim".into(),
             editor_args: None,
-            template: None,
             edit_code_marker: false,
             start_marker: "".into(),
             end_marker: "".into(),
+            inject_before: None,
+            inject_after: None,
             comment_problem_desc: false,
             comment_leading: "".into(),
             test: true,

--- a/src/config/code.rs
+++ b/src/config/code.rs
@@ -16,6 +16,8 @@ pub struct Code {
     pub editor: String,
     #[serde(rename(serialize = "editor-args"), alias = "editor-args", default)]
     pub editor_args: Option<Vec<String>>,
+    #[serde(rename(serialize = "template"), alias = "template", default)]
+    pub template: Option<Vec<String>>,
     #[serde(default, skip_serializing)]
     pub edit_code_marker: bool,
     #[serde(default, skip_serializing)]
@@ -40,6 +42,7 @@ impl Default for Code {
         Self {
             editor: "vim".into(),
             editor_args: None,
+            template: None,
             edit_code_marker: false,
             start_marker: "".into(),
             end_marker: "".into(),


### PR DESCRIPTION
This makes it possible to automate the process of importing missing libraries (no more lsp/linting errors, yay!) and to quickly generate the boilerplate necessary to test code locally.

Inspired by a similar feature in leetup (https://github.com/dragfire/leetup#inject-code-fragments)