### PR TITLE
feat: add option to set environment variables for edit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ To configure leetcode-cli, create a file at `~/.leetcode/leetcode.toml`):
 editor = 'emacs'
 # Optional parameter
 editor_args = ['-nw']
+# Optional environment variables (ex. [ "XDG_DATA_HOME=...", "XDG_CONFIG_HOME=...", "XDG_STATE_HOME=..." ])
+editor_envs = []
 lang = 'rust'
 edit_code_marker = false
 start_marker = ""
@@ -104,6 +106,8 @@ scripts = 'scripts'
 editor = 'emacs'
 # Optional parameter
 editor_args = ['-nw']
+# Optional environment variables (ex. [ "XDG_DATA_HOME=...", "XDG_CONFIG_HOME=...", "XDG_STATE_HOME=..." ])
+editor_envs = []
 lang = 'rust'
 edit_code_marker = true
 start_marker = "start_marker"

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Some linting tools/lsps will throw errors unless the necessary libraries are imp
 
 ```toml
 [code]
-inject_before = ["#include<bits/stdc++.h", "using namespace std;"]
+inject_before = ["#include<bits/stdc++.h>", "using namespace std;"]
 inject_after = ["int main() {\n    Solution solution;\n\n}"]
 ```
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -115,7 +115,7 @@ impl Cache {
         let p: Problem = problems.filter(fid.eq(rfid)).first(&mut self.conn()?)?;
         if p.category != "algorithms" {
             return Err(Error::FeatureError(
-                "Not support database and shell questions for now".to_string(),
+                "No support for database and shell questions yet".to_string(),
             ));
         }
 
@@ -129,7 +129,7 @@ impl Cache {
             .first(&mut self.conn()?)?;
         if p.category != "algorithms" {
             return Err(Error::FeatureError(
-                "Not support database and shell questions for now".to_string(),
+                "No support for database and shell questions yet".to_string(),
             ));
         }
         Ok(p.fid)
@@ -174,7 +174,7 @@ impl Cache {
 
         if target.category != "algorithms" {
             return Err(Error::FeatureError(
-                "Not support database and shell questions for now".to_string(),
+                "No support for database and shell questions yet".to_string(),
             ));
         }
 
@@ -255,7 +255,7 @@ impl Cache {
         rfid: i32,
         test_case: Option<String>,
     ) -> Result<(HashMap<&'static str, String>, [String; 2]), Error> {
-        trace!("pre run code...");
+        trace!("pre-run code...");
         use crate::helper::code_path;
         use std::fs::File;
         use std::io::Read;

--- a/src/cmds/edit.rs
+++ b/src/cmds/edit.rs
@@ -161,8 +161,21 @@ impl Command for EditCommand {
             args.extend_from_slice(&editor_args);
         }
 
+        let editor_env = &conf.code.editor_env;
+        let mut env: Vec<&str> = vec!["", ""];
+        if !editor_env.is_empty() {
+            env = editor_env.splitn(2, '=').collect();
+            if env.len() != 2 {
+                return Err(crate::Error::FeatureError(
+                    "Invalid environment variable, please check your configuration for errors"
+                        .into(),
+                ));
+            }
+        }
+
         args.push(path);
         std::process::Command::new(conf.code.editor)
+            .env(env[0], env[1])
             .args(args)
             .status()?;
         Ok(())

--- a/src/cmds/edit.rs
+++ b/src/cmds/edit.rs
@@ -3,6 +3,7 @@ use super::Command;
 use crate::Error;
 use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command as ClapCommand};
+use std::collections::HashMap;
 
 /// Abstract `edit` command
 ///
@@ -161,21 +162,39 @@ impl Command for EditCommand {
             args.extend_from_slice(&editor_args);
         }
 
-        let editor_env = &conf.code.editor_env;
-        let mut env: Vec<&str> = vec!["", ""];
-        if !editor_env.is_empty() {
-            env = editor_env.splitn(2, '=').collect();
-            if env.len() != 2 {
-                return Err(crate::Error::FeatureError(
-                    "Invalid environment variable, please check your configuration for errors"
-                        .into(),
-                ));
+        // Set environment variables for editor
+        //
+        // for example:
+        //
+        // ```toml
+        // [code]
+        // editor = "nvim"
+        // editor_envs = [ "XDG_DATA_HOME=...", "XDG_CONFIG_HOME=...", "XDG_STATE_HOME=..." ]
+        // ```
+        //
+        // ```rust
+        // Command::new("nvim").envs(&[ ("XDG_DATA_HOME", "..."), ("XDG_CONFIG_HOME", "..."), ("XDG_STATE_HOME", "..."), ]);
+        // ```
+        let mut envs: HashMap<String, String> = Default::default();
+        if let Some(editor_envs) = &conf.code.editor_envs {
+            for env in editor_envs.iter() {
+                let parts: Vec<&str> = env.split('=').collect();
+                if parts.len() == 2 {
+                    let name = parts[0].trim();
+                    let value = parts[1].trim();
+                    envs.insert(name.to_string(), value.to_string());
+                } else {
+                    return Err(crate::Error::FeatureError(format!(
+                        "Invalid editor environment variable: {}",
+                        &env
+                    )));
+                }
             }
         }
 
         args.push(path);
         std::process::Command::new(conf.code.editor)
-            .env(env[0], env[1])
+            .envs(envs)
             .args(args)
             .status()?;
         Ok(())

--- a/src/config/code.rs
+++ b/src/config/code.rs
@@ -17,6 +17,8 @@ pub struct Code {
     #[serde(rename(serialize = "editor-args"), alias = "editor-args", default)]
     pub editor_args: Option<Vec<String>>,
     #[serde(default, skip_serializing)]
+    pub editor_env: String,
+    #[serde(default, skip_serializing)]
     pub edit_code_marker: bool,
     #[serde(default, skip_serializing)]
     pub start_marker: String,
@@ -44,6 +46,7 @@ impl Default for Code {
         Self {
             editor: "vim".into(),
             editor_args: None,
+            editor_env: "".into(),
             edit_code_marker: false,
             start_marker: "".into(),
             end_marker: "".into(),

--- a/src/config/code.rs
+++ b/src/config/code.rs
@@ -16,8 +16,8 @@ pub struct Code {
     pub editor: String,
     #[serde(rename(serialize = "editor-args"), alias = "editor-args", default)]
     pub editor_args: Option<Vec<String>>,
-    #[serde(default, skip_serializing)]
-    pub editor_env: String,
+    #[serde(rename(serialize = "editor-envs"), alias = "editor-envs", default)]
+    pub editor_envs: Option<Vec<String>>,
     #[serde(default, skip_serializing)]
     pub edit_code_marker: bool,
     #[serde(default, skip_serializing)]
@@ -46,7 +46,7 @@ impl Default for Code {
         Self {
             editor: "vim".into(),
             editor_args: None,
-            editor_env: "".into(),
+            editor_envs: None,
             edit_code_marker: false,
             start_marker: "".into(),
             end_marker: "".into(),


### PR DESCRIPTION
This makes it possible to set environment variables for the edit command. An example use case for neovim users would be to set the `NVIM_APPNAME` variable, which will allow you to choose a specific neovim profile to edit with.