### PR TITLE
fix: Problems' description (pick, edit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,7 +1327,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "leetcode-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/cache/models.rs
+++ b/src/cache/models.rs
@@ -151,7 +151,7 @@ impl Question {
     }
 
     pub fn desc_comment(&self, conf: &Config) -> String {
-        let desc = self.t_content.render();
+        let desc = self.content.render();
 
         let mut res = desc.lines().fold("\n".to_string(), |acc, e| {
             acc + "" + conf.code.comment_leading.as_str() + " " + e + "\n"

--- a/src/cache/parser.rs
+++ b/src/cache/parser.rs
@@ -98,7 +98,7 @@ pub fn tags(v: Value) -> Option<Vec<String>> {
 pub fn daily(v: Value) -> Option<i32> {
     trace!("Parse daily...");
     let v_obj = v.as_object()?.get("data")?.as_object()?;
-    match v_obj.get("dailyQuestionRecord") {
+    match v_obj.get("activeDailyCodingChallengeQuestion") {
         // Handle on leetcode-com
         Some(v) => v,
         // Handle on leetcode-cn

--- a/src/cmds/pick.rs
+++ b/src/cmds/pick.rs
@@ -130,7 +130,12 @@ impl Command for PickCommand {
             crate::helper::filter(&mut problems, query.to_string());
         }
 
-        let daily_id = if m.contains_id("daily") {
+        let daily = match m.get_one::<bool>("daily") {
+            Some(x) => x,
+            None => &false,
+        };
+
+        let daily_id = if *daily {
             Some(cache.get_daily_problem_id().await?)
         } else {
             None


### PR DESCRIPTION
Changed a key to fix parsing of daily problem request (dailyQuestionRecord -> activeDailyCodingChallengeQuestion). 

Fixed when id for daily problem should be fetched. Before, it will always be fetched for the `pick` option regardless of the existence of the `-d` option

Fixed comment problem desc to correctly add problem description by changing the Question to render `Question.content` instead of `Question.t_content` (which was empty).