### PR TITLE
fix(flake.nix): add `SystemConfiguration` for Darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           openssl
           dbus
           sqlite
-        ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
+        ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Security SystemConfiguration ]);
 
 
         package = with pkgs; rustPlatform.buildRustPackage rec {


### PR DESCRIPTION
fixes: #166

The error looks like we need to add `SystemConfiguration` for Darwin environment.

I got an advice for this PR from @blyoa