### PR TITLE
Add `--daily` cli option for `edit`, `test` and `exec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leetcode-cli"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ path = "src/bin/lc.rs"
 
 [package]
 name = "leetcode-cli"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["clearloop <tianyi.gc@gmail.com>"]
 edition = "2021"
 description = "Leetcode command-line interface in rust."

--- a/src/cmds/exec.rs
+++ b/src/cmds/exec.rs
@@ -2,7 +2,7 @@
 use super::Command;
 use crate::{Error, Result};
 use async_trait::async_trait;
-use clap::{Arg, ArgMatches, Command as ClapCommand};
+use clap::{Arg, ArgAction, ArgGroup, ArgMatches, Command as ClapCommand};
 
 /// Abstract Exec Command
 ///
@@ -36,14 +36,40 @@ impl Command for ExecCommand {
                     .value_parser(clap::value_parser!(i32))
                     .help("question id"),
             )
+            .arg(
+                Arg::new("daily")
+                    .short('d')
+                    .long("daily")
+                    .help("Edit today's daily challenge")
+                    .action(ArgAction::SetTrue),
+            )
+            .group(
+                ArgGroup::new("question-id")
+                    .args(["id", "daily"])
+                    .multiple(false)
+                    .required(true),
+            )
     }
 
     /// `exec` handler
     async fn handler(m: &ArgMatches) -> Result<()> {
         use crate::cache::{Cache, Run};
 
-        let id: i32 = *m.get_one::<i32>("id").ok_or(Error::NoneError)?;
         let cache = Cache::new()?;
+
+        let daily = m.get_one::<bool>("daily").unwrap_or(&false);
+        let daily_id = if *daily {
+            Some(cache.get_daily_problem_id().await?)
+        } else {
+            None
+        };
+
+        let id = m
+            .get_one::<i32>("id")
+            .copied()
+            .or(daily_id)
+            .ok_or(Error::NoneError)?;
+
         let res = cache.exec_problem(id, Run::Submit, None).await?;
 
         println!("{}", res);

--- a/src/cmds/exec.rs
+++ b/src/cmds/exec.rs
@@ -40,7 +40,7 @@ impl Command for ExecCommand {
                 Arg::new("daily")
                     .short('d')
                     .long("daily")
-                    .help("Edit today's daily challenge")
+                    .help("Exec today's daily challenge")
                     .action(ArgAction::SetTrue),
             )
             .group(

--- a/src/cmds/test.rs
+++ b/src/cmds/test.rs
@@ -2,7 +2,7 @@
 use super::Command;
 use crate::{Error, Result};
 use async_trait::async_trait;
-use clap::{Arg, ArgMatches, Command as ClapCommand};
+use clap::{Arg, ArgAction, ArgGroup, ArgMatches, Command as ClapCommand};
 
 /// Abstract Test Command
 ///
@@ -27,12 +27,11 @@ impl Command for TestCommand {
     /// `test` usage
     fn usage() -> ClapCommand {
         ClapCommand::new("test")
-            .about("Test question by id")
+            .about("Test a question")
             .visible_alias("t")
             .arg(
                 Arg::new("id")
                     .num_args(1)
-                    .required(true)
                     .value_parser(clap::value_parser!(i32))
                     .help("question id"),
             )
@@ -42,18 +41,45 @@ impl Command for TestCommand {
                     .required(false)
                     .help("custom testcase"),
             )
+            .arg(
+                Arg::new("daily")
+                    .short('d')
+                    .long("daily")
+                    .help("Test today's daily challenge")
+                    .action(ArgAction::SetTrue),
+            )
+            .group(
+                ArgGroup::new("question-id")
+                    .args(["id", "daily"])
+                    .multiple(false)
+                    .required(true),
+            )
     }
 
     /// `test` handler
     async fn handler(m: &ArgMatches) -> Result<()> {
         use crate::cache::{Cache, Run};
-        let id: i32 = *m.get_one::<i32>("id").ok_or(Error::NoneError)?;
+
+        let cache = Cache::new()?;
+
+        let daily = m.get_one::<bool>("daily").unwrap_or(&false);
+        let daily_id = if *daily {
+            Some(cache.get_daily_problem_id().await?)
+        } else {
+            None
+        };
+
+        let id = m
+            .get_one::<i32>("id")
+            .copied()
+            .or(daily_id)
+            .ok_or(Error::NoneError)?;
+
         let testcase = m.get_one::<String>("testcase");
         let case_str: Option<String> = match testcase {
             Some(case) => Option::from(case.replace("\\n", "\n")),
             _ => None,
         };
-        let cache = Cache::new()?;
         let res = cache.exec_problem(id, Run::Test, case_str).await?;
 
         println!("{}", res);


### PR DESCRIPTION
I really like `--daily` option added to `pick` by #66, and was surprised this function is not present in rest of the subcommands.