### PR TITLE
fix: fix some format errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ scraper = "0.23.1"
 anyhow = "1.0.97"
 clap_complete = "4.5.47"
 thiserror = "2.0.12"
+unicode-width = "0.1"
 
 [dependencies.diesel]
 version = "2.2.8"


### PR DESCRIPTION
`leetcode list` display abnormally when language of question title is Chinese.

Before patch:
<img width="1007" alt="image" src="https://github.com/user-attachments/assets/4edcb29f-63e5-4d63-a63e-204647f3ba63" />
<img width="933" alt="image" src="https://github.com/user-attachments/assets/3fef2d66-806f-4b2b-acc5-c4715b35a93b" />

After patch:
<img width="993" alt="image" src="https://github.com/user-attachments/assets/8703e59f-4e9e-44a1-92cd-5c1771380e7d" />
<img width="945" alt="image" src="https://github.com/user-attachments/assets/fb2c8419-e90e-4d9b-a8ea-1c005e222011" />
