### PR TITLE
Add environment variable override for cookie configuration

### DIFF
--- a/src/config/cookies.rs
+++ b/src/config/cookies.rs
@@ -62,3 +62,27 @@ impl Display for Cookies {
         )
     }
 }
+
+/// Override cookies from environment variables
+pub const LEETCODE_CSRF_ENV: &str = "LEETCODE_CSRF";
+pub const LEETCODE_SESSION_ENV: &str = "LEETCODE_SESSION";
+pub const LEETCODE_SITE_ENV: &str = "LEETCODE_SITE";
+
+impl Cookies {
+    /// Load cookies from environment variables, overriding any existing values
+    /// if the environment variables are set.
+    pub fn with_env_override(mut self) -> Self {
+        if let Ok(csrf) = std::env::var(LEETCODE_CSRF_ENV) {
+            self.csrf = csrf;
+        }
+        if let Ok(session) = std::env::var(LEETCODE_SESSION_ENV) {
+            self.session = session;
+        }
+        if let Ok(site) = std::env::var(LEETCODE_SITE_ENV) {
+            if let Ok(leetcode_site) = LeetcodeSite::from_str(&site) {
+                self.site = leetcode_site;
+            }
+        }
+        self
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -46,14 +46,19 @@ impl Config {
 
         let s = fs::read_to_string(&conf)?;
         match toml::from_str::<Config>(&s) {
-            Ok(config) => match config.cookies.site {
-                cookies::LeetcodeSite::LeetcodeCom => Ok(config),
-                cookies::LeetcodeSite::LeetcodeCn => {
-                    let mut config = config;
-                    config.sys.urls = sys::Urls::new_with_leetcode_cn();
-                    Ok(config)
+            Ok(mut config) => {
+                // Override config.cookies with environment variables
+                config.cookies = config.cookies.with_env_override();
+
+                match config.cookies.site {
+                    cookies::LeetcodeSite::LeetcodeCom => Ok(config),
+                    cookies::LeetcodeSite::LeetcodeCn => {
+                        let mut config = config;
+                        config.sys.urls = sys::Urls::new_with_leetcode_cn();
+                        Ok(config)
+                    }
                 }
-            },
+            }
             Err(e) => {
                 let tmp = Self::root()?.join("leetcode.tmp.toml");
                 Self::write_default(tmp)?;


### PR DESCRIPTION
Cookies can now be overridden using LEETCODE_CSRF, LEETCODE_SESSION, and LEETCODE_SITE environment variables when loading configuration. I think someone might want to split their cookies from `leetcode.toml` and keep other configurations in `leetcode.toml` synchronized by git, e.g., me 🤣.

## TODO

- Update README.md with corresponding doc.