### PR TITLE
Add per-problem Cargo.toml and subdir structure for Rust LSP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,22 @@ pub fn three_sum(nums: Vec<i32>) -> Vec<Vec<i32>> {
 
 </details>
 
+## Language-Specific Configuration
+
+### Rust
+For `lang = 'rust'`, leetcode-cli generates per-problem crate structures to enable full LSP support (e.g., rust-analyzer in editors like Helix or VS Code).
+
+- **Structure**: `code/{fid}-{slug}/src/lib.rs` (code), `tests.dat` (test cases), and `Cargo.toml` (basic crate config with commented dependencies for common crates like `itertools` or `regex`).
+- **Example**: For problem 1 ("Two Sum"), creates `code/1-two_sum/` with `prob-1-two_sum` as package name.
+- **Config Option**: Set `enable_rust_crates = false` in `[code]` to fall back to flat files (e.g., `1.two-sum.rs`).
+- **Usage**: Run `leetcode edit 1`, then open the dir: `hx code/1-two_sum/` for LSP features (autocomplete, diagnostics, etc.).
+- **Migration**: If flat files exist, the tool notes them—manually move content to `lib.rs` if needed.
+- **Local Testing**: Edit `Cargo.toml` to add deps, then `cargo check` or `cargo test` (tests.dat can be adapted for unit tests).
+
+This keeps submissions unchanged (sends code snippet to LeetCode API) while improving local editing.
+
+For other languages, files remain flat. Future support for similar setups (e.g., Python virtualenvs) can be added via config.
+
 <br>
 
 Some linting tools/lsps will throw errors unless the necessary libraries are imported. leetcode-cli can generate this boilerplate automatically if the `inject_before` key is set. Similarly, if you want to test out your code locally, you can automate that with `inject_after`. For c++ this might look something like:

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ For `lang = 'rust'`, leetcode-cli generates per-problem crate structures to enab
 
 This keeps submissions unchanged (sends code snippet to LeetCode API) while improving local editing.
 
-For other languages, files remain flat. Future support for similar setups (e.g., Python virtualenvs) can be added via config.
+For other languages, files remain flat. Please contribute if needed!
 
 <br>
 

--- a/src/cmds/edit.rs
+++ b/src/cmds/edit.rs
@@ -108,7 +108,7 @@ use std::path::Path;
 let question: Question = qr?;
 
 if *lang == "rust" {
-    let sanitized_slug = problem.slug.replace(|c: char| !c.is_alphanumeric(), "_");
+    let sanitized_slug = problem.slug.to_lowercase().replace(|c: char| !c.is_alphanumeric(), "_");
     let code_dir_str = format!("{}/{}-{}", conf.storage.code()?, problem.fid, sanitized_slug);
     let code_dir = Path::new(&code_dir_str);
     fs::create_dir_all(code_dir)?;
@@ -120,7 +120,7 @@ if *lang == "rust" {
     let cargo_path_str = format!("{}/Cargo.toml", code_dir_str);
     let cargo_path = Path::new(&cargo_path_str);
     if !cargo_path.exists() {
-        let package_name = format!("leetcode-{}-{}", problem.fid, sanitized_slug);
+        let package_name = format!("prob-{}-{}", problem.fid, sanitized_slug);
         let cargo_content = format!(
 r#"[package]
 name = "{}"

--- a/src/cmds/edit.rs
+++ b/src/cmds/edit.rs
@@ -121,7 +121,7 @@ if *lang == "rust" {
     let cargo_path = Path::new(&cargo_path_str);
     if !cargo_path.exists() {
         let package_name = format!("prob-{}-{}", problem.fid, sanitized_slug);
-        let cargo_content = format!(
+let cargo_content = format!(
 r#"[package]
 name = "{}"
 version = "0.1.0"
@@ -131,9 +131,12 @@ edition = "2021"
 path = "src/lib.rs"
 
 [dependencies]
+# Uncomment and add crates as needed for LeetCode problems, e.g.:
+# itertools = "0.12"
+# regex = "1"
 "#,
-            package_name
-        );
+    package_name
+);
         let mut cargo_file = File::create(&cargo_path_str)?;
         cargo_file.write_all(cargo_content.as_bytes())?;
     }

--- a/src/cmds/edit.rs
+++ b/src/cmds/edit.rs
@@ -108,7 +108,7 @@ use std::path::Path;
 
 let question: Question = qr?;
 
-if *lang == "rust" {
+if *lang == "rust" && conf.code.enable_rust_crates {
     let flat_suffix = suffix(&lang).map_err(anyhow::Error::msg)?;  // Since suffix returns Result<&str>
     let pick_replaced = conf.code.pick.replace("${fid}", &problem.fid.to_string()).replace("${slug}", &problem.slug.to_string());
     let flat_path_str = format!("{}/{}.{}", conf.storage.code()?, pick_replaced, flat_suffix);

--- a/src/cmds/edit.rs
+++ b/src/cmds/edit.rs
@@ -62,6 +62,7 @@ impl Command for EditCommand {
     /// `edit` handler
     async fn handler(m: &ArgMatches) -> Result<()> {
         use crate::{cache::models::Question, Cache};
+use crate::helper::suffix;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
@@ -108,6 +109,13 @@ use std::path::Path;
 let question: Question = qr?;
 
 if *lang == "rust" {
+    let flat_suffix = suffix(&lang).map_err(anyhow::Error::msg)?;  // Since suffix returns Result<&str>
+    let pick_replaced = conf.code.pick.replace("${fid}", &problem.fid.to_string()).replace("${slug}", &problem.slug.to_string());
+    let flat_path_str = format!("{}/{}.{}", conf.storage.code()?, pick_replaced, flat_suffix);
+    if Path::new(&flat_path_str).exists() {
+        println!("Note: Existing flat file at {}. Consider migrating content to new subdir structure.", flat_path_str);
+    }
+
     let sanitized_slug = problem.slug.to_lowercase().replace(|c: char| !c.is_alphanumeric(), "_");
     let code_dir_str = format!("{}/{}-{}", conf.storage.code()?, problem.fid, sanitized_slug);
     let code_dir = Path::new(&code_dir_str);

--- a/src/config/code.rs
+++ b/src/config/code.rs
@@ -9,6 +9,10 @@ fn default_submission() -> String {
     "${fid}.${slug}.${sid}.${ac}".into()
 }
 
+fn default_enable_rust_crates() -> bool {
+    true
+}
+
 /// Code config
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Code {
@@ -34,6 +38,7 @@ pub struct Code {
     pub comment_leading: String,
     #[serde(default, skip_serializing)]
     pub test: bool,
+    pub enable_rust_crates: bool,
     pub lang: String,
     #[serde(default = "default_pick", skip_serializing)]
     pub pick: String,
@@ -55,6 +60,7 @@ impl Default for Code {
             comment_problem_desc: false,
             comment_leading: "".into(),
             test: true,
+            enable_rust_crates: default_enable_rust_crates(),
             lang: "rust".into(),
             pick: "${fid}.${slug}".into(),
             submission: "${fid}.${slug}.${sid}.${ac}".into(),

--- a/src/config/code.rs
+++ b/src/config/code.rs
@@ -38,7 +38,8 @@ pub struct Code {
     pub comment_leading: String,
     #[serde(default, skip_serializing)]
     pub test: bool,
-    pub enable_rust_crates: bool,
+    #[serde(default = "default_enable_rust_crates")]
+pub enable_rust_crates: bool,
     pub lang: String,
     #[serde(default = "default_pick", skip_serializing)]
     pub pick: String,

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -191,7 +191,7 @@ mod file {
         }
     }
 
-    use crate::{cache::models::Problem, Error};
+    use crate::cache::models::Problem;
 
     /// Generate test cases path by fid
 pub fn test_cases_path(problem: &Problem) -> crate::Result<String> {

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -200,7 +200,7 @@ pub fn test_cases_path(problem: &Problem) -> crate::Result<String> {
     let code_base = conf.storage.code()?;
 
     let path = if lang == "rust" {
-        let sanitized_slug = problem.slug.replace(|c: char| !c.is_alphanumeric(), "_");
+        let sanitized_slug = problem.slug.to_lowercase().replace(|c: char| !c.is_alphanumeric(), "_");
         let subdir = format!("{}-{}/tests.dat", problem.fid, sanitized_slug);
         format!("{}/{}", code_base, subdir)
     } else {
@@ -224,7 +224,7 @@ pub fn code_path(problem: &Problem, l: Option<String>) -> crate::Result<String> 
     let code_base = conf.storage.code()?;
 
     let path = if lang == "rust" {
-        let sanitized_slug = problem.slug.replace(|c: char| !c.is_alphanumeric(), "_");
+        let sanitized_slug = problem.slug.to_lowercase().replace(|c: char| !c.is_alphanumeric(), "_");
         let subdir = format!("{}-{}/src/lib.rs", problem.fid, sanitized_slug);
         format!("{}/{}", code_base, subdir)
     } else {

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,7 +1,7 @@
 //! A set of helper traits
 pub use self::{
     digit::Digit,
-    file::{code_path, load_script, test_cases_path},
+    file::{code_path, load_script, suffix, test_cases_path},
     filter::{filter, squash},
     html::HTML,
 };

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -197,9 +197,10 @@ mod file {
 pub fn test_cases_path(problem: &Problem) -> crate::Result<String> {
     let conf = crate::config::Config::locate()?;
     let lang = conf.code.lang.clone();
+    let use_crates = conf.code.enable_rust_crates;
     let code_base = conf.storage.code()?;
 
-    let path = if lang == "rust" {
+    let path = if lang == "rust" && use_crates {
         let sanitized_slug = problem.slug.to_lowercase().replace(|c: char| !c.is_alphanumeric(), "_");
         let subdir = format!("{}-{}/tests.dat", problem.fid, sanitized_slug);
         format!("{}/{}", code_base, subdir)
@@ -221,9 +222,10 @@ pub fn code_path(problem: &Problem, l: Option<String>) -> crate::Result<String> 
         lang = lang_opt;
     }
 
+    let use_crates = conf.code.enable_rust_crates;
     let code_base = conf.storage.code()?;
 
-    let path = if lang == "rust" {
+    let path = if lang == "rust" && use_crates {
         let sanitized_slug = problem.slug.to_lowercase().replace(|c: char| !c.is_alphanumeric(), "_");
         let subdir = format!("{}-{}/src/lib.rs", problem.fid, sanitized_slug);
         format!("{}/{}", code_base, subdir)


### PR DESCRIPTION
## Summary
- For `lang = 'rust'`, generates subdir crates (e.g., `code/1-two_sum/src/lib.rs`, `Cargo.toml` with `prob-1-two_sum` package, `tests.dat`).
- Enables full rust-analyzer LSP in editors (autocomplete, diagnostics) without breaking LeetCode API submissions (still extracts code snippet).
- New config: `[code] enable_rust_crates = true` (default; set false for flat files).
- Backward compatible: Legacy configs load with default true; notes existing flat files.
- Enhancements: Sanitized names, commented deps in Cargo.toml, error handling.

## Changes
- Updated paths in `helper.rs` (conditional subdirs).
- Added dir/Cargo.toml creation in `cmds/edit.rs`.
- Configurable via new field in `config/code.rs`.
- Docs: New README section on Rust setup.

## Testing
- Manual: `leetcode edit 1` creates structure; `test 1`/`exec 1` work.
- LSP: Open dir in Helix/VS Code—full features.
- Flat fallback: Set `enable_rust_crates = false` and edit another problem.

Closes #204 . Ready for review!