### PR TITLE
fix: import rand::RngExt so pick compiles after rand 0.10 bump

### DIFF
--- a/src/cmd/pick.rs
+++ b/src/cmd/pick.rs
@@ -44,7 +44,7 @@ impl PickArgs {
     /// `pick` handler
     pub async fn run(&self) -> Result<(), Error> {
         use crate::cache::Cache;
-        use rand::Rng;
+        use rand::RngExt;
 
         let cache = Cache::new()?;
         let mut problems = cache.get_problems()?;


### PR DESCRIPTION
`main` currently fails to compile. The `rand` 0.10 upgrade in #220 moved `random_range` off the `Rng` trait and into the new `RngExt` trait, but `src/cmd/pick.rs` still imports `rand::Rng`:

```
error[E0599]: no method named `random_range` found for struct `ThreadRng` in the current scope
   --> src/cmd/pick.rs:89:53
    |
 89 |     let problem = &problems[rand::rng().random_range(0..problems.len())];
    |                                         ^^^^^^^^^^^^
    |
help: trait `RngExt` which provides `random_range` is implemented but not in scope; perhaps you want to import it
    |
  2 + use rand::RngExt;
```

`cargo build --release` fails on a clean checkout of `main`.


This is fixed by importing `rand::RngExt` instead of `rand::Rng` in the `pick` handler — that's the trait now providing `random_range` in rand 0.10. It's verified by checking `cargo build --release` succeeds, and `leetcode pick` (random pick) works as before.