### PR TITLE
fix: bundle sqlite so leetcode-cli builds without a system libsqlite3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,21 +1191,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,7 +1909,6 @@ dependencies = [
  "log",
  "nix 0.31.3",
  "notify",
- "openssl",
  "pyo3",
  "rand 0.10.1",
  "regex",
@@ -2257,47 +2241,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,6 +1920,7 @@ dependencies = [
  "diesel",
  "dirs",
  "env_logger",
+ "libsqlite3-sys",
  "log",
  "nix 0.31.3",
  "notify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,7 +1910,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leetcode-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ colored = "3.1.1"
 dirs = "6.0.0"
 env_logger = "0.11.6"
 log = "0.4.31"
-openssl = "0.10"
 pyo3 = { version = "0.29", optional = true }
 rand = "0.10.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = "2.0.18"
 unicode-width = "0.2"
 notify = "8.2.0"
 rookie = "0.5.6"
+libsqlite3-sys = { version = "0.28", features = ["bundled"] }
 
 [dependencies.diesel]
 version = "2.3.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ path = "src/bin/lc.rs"
 
 [package]
 name = "leetcode-cli"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["clearloop <tianyi.gc@gmail.com>"]
 edition = "2024"
 description = "Leetcode command-line interface in rust."

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ May the code be with you.
 ## Install
 
 ```sh
-# Required dependencies: gcc, libssl-dev, libdbus-1-dev, libsqlite3-dev
+# Required dependencies: gcc, libssl-dev, libdbus-1-dev
 cargo install leetcode-cli
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ May the code be with you.
 ## Install
 
 ```sh
-# Required dependencies: gcc, libssl-dev, libdbus-1-dev
+# Required dependencies: gcc, cmake (to build the bundled sqlite and aws-lc)
 cargo install leetcode-cli
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,6 @@
         buildInputs = with pkgs; [
           openssl
           dbus
-          sqlite
         ] ++ darwinBuildInputs;
 
         package = naersk'.buildPackage rec {

--- a/flake.nix
+++ b/flake.nix
@@ -50,8 +50,6 @@
         ];
 
         buildInputs = with pkgs; [
-          openssl
-          dbus
         ] ++ darwinBuildInputs;
 
         package = naersk'.buildPackage rec {

--- a/src/err.rs
+++ b/src/err.rs
@@ -66,8 +66,6 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error(transparent)]
     Anyhow(#[from] anyhow::Error),
-    #[error(transparent)]
-    OpenSSL(#[from] openssl::error::ErrorStack),
     #[cfg(feature = "pym")]
     #[error(transparent)]
     Pyo3(#[from] pyo3::PyErr),


### PR DESCRIPTION
Closes #226

## Problem

leetcode-cli 0.5.1 fails to build in a clean packaging environment (e.g. the AUR chroot) with `undefined symbol: sqlite3_step` and other `sqlite3_*` link errors.

## Root cause

0.5.1 added `rookie` (browser-cookie decryption), which pulls `rusqlite` → `libsqlite3-sys` with the `bundled` feature. The project also uses `diesel`'s sqlite backend, which depends on the *same* `libsqlite3-sys v0.28.0` but with only `bundled_bindings` — it expects to link an external sqlite3 library. Whether the build succeeds then hinges on Cargo unifying `bundled` onto that single shared crate. On macOS and on GitHub's `ubuntu-latest` runner this is masked because a system `libsqlite3` is always present as a fallback. In a clean Linux chroot `bundled` was not active (the link line carries the `libsqlite3-sys/out` search path but no `-lsqlite3` and no static archive), so nothing compiled the amalgamation and there is no system sqlite to fall back on → undefined symbols. This is also why CI never caught it: the runners ship sqlite.

## Fix

Demand `bundled` directly from the root crate so it is present in every feature resolution and every environment, with no dependency on a system sqlite:

```toml
libsqlite3-sys = { version = "0.28", features = ["bundled"] }
```

This isn't new vendoring — `rookie` → `rusqlite` already bundles unconditionally; this just makes it deterministic instead of relying on accidental feature unification.

## Dependency cleanup

While confirming the documented system dependencies, two more turned out to be stale:

- **`libdbus-1-dev` — not needed.** Nothing links the C dbus library; `zbus` (via `rookie`) is pure Rust. Leftover from `keyring`, which was removed in 0.5.1.
- **`libssl-dev` / `openssl` — dead code.** The `openssl` crate was referenced in exactly one place: an `Error::OpenSSL` variant that was never constructed. TLS goes through rustls; `openssl-sys` was pulled solely by that one direct dependency. Removed the variant and the dependency (−53 lines from `Cargo.lock`).

The required system surface is now just a C toolchain (`gcc`, `cmake`) to build the bundled native code. README and `flake.nix` updated accordingly, and the patch version is bumped to 0.5.2.

## Verification

Single `libsqlite3-sys v0.28.0` in the tree; `cargo build --release`, `cargo fmt --check`, and `cargo clippy --all-features` all pass.